### PR TITLE
Update speed_dial.dart

### DIFF
--- a/lib/src/speed_dial.dart
+++ b/lib/src/speed_dial.dart
@@ -188,7 +188,7 @@ class _SpeedDialState extends State<SpeedDial> with TickerProviderStateMixin {
               if (!widget.closeManually) _toggleChildren();
             },
             shape: child.shape,
-            heroTag: 'speed-dial-child-$index',
+            heroTag: widget.heroTag != null ? 'speed-dial-child-$index' : null,
           );
         })
         .toList()


### PR DESCRIPTION
Hero tags should be set to null if they are not used. Setting the heroTag to null prevents the FAB from being wrapped in a hero widget. Hero widgets cannot be the descendant of another Hero widget so heroTags should be set null if they are not used, allowing the FAB to have more flexibility.