### PR TITLE
Huge optimization by removing unnecessary AnimationControllers

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -21,7 +21,8 @@ class MyAppState extends State<MyApp> with TickerProviderStateMixin {
 
     _scrollController = ScrollController()
       ..addListener(() {
-        _setDialVisible(_scrollController.position.userScrollDirection == ScrollDirection.forward);
+        _setDialVisible(_scrollController.position.userScrollDirection ==
+            ScrollDirection.forward);
       });
   }
 

--- a/lib/src/speed_dial.dart
+++ b/lib/src/speed_dial.dart
@@ -76,7 +76,8 @@ class SpeedDial extends StatefulWidget {
   _SpeedDialState createState() => _SpeedDialState();
 }
 
-class _SpeedDialState extends State<SpeedDial> with TickerProviderStateMixin {
+class _SpeedDialState extends State<SpeedDial>
+    with SingleTickerProviderStateMixin {
   AnimationController _controller;
 
   bool _open = false;

--- a/lib/src/speed_dial.dart
+++ b/lib/src/speed_dial.dart
@@ -85,12 +85,14 @@ class _SpeedDialState extends State<SpeedDial>
   @override
   void initState() {
     super.initState();
-
     _controller = AnimationController(
-      duration: Duration(milliseconds: 200),
+      duration: _calculateMainControllerDuration(),
       vsync: this,
     );
   }
+
+  Duration _calculateMainControllerDuration() =>
+      Duration(milliseconds: 150 + widget.children.length * 30);
 
   @override
   void dispose() {
@@ -105,6 +107,15 @@ class _SpeedDialState extends State<SpeedDial>
     } else {
       _controller.reverse();
     }
+  }
+
+  @override
+  void didUpdateWidget(SpeedDial oldWidget) {
+    if (oldWidget.children.length != widget.children.length) {
+      _controller.duration = _calculateMainControllerDuration();
+    }
+
+    super.didUpdateWidget(oldWidget);
   }
 
   void _toggleChildren() {
@@ -127,8 +138,7 @@ class _SpeedDialState extends State<SpeedDial>
           var childAnimation = Tween(begin: 0.0, end: 62.0).animate(
             CurvedAnimation(
               parent: this._controller,
-              curve: Interval(singleChildrenTween * index,
-                  singleChildrenTween * (index + 1)),
+              curve: Interval(0, singleChildrenTween * (index + 1)),
             ),
           );
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_speed_dial
 description: Flutter plugin to implement a beautiful and dynamic Material Design Speed Dial, with labels, animated icons and hide on scrolling.
-version: 1.1.2
+version: 1.2.0
 author: Dario Ielardi <dario.ielardi@gmail.com>
 homepage: https://github.com/darioielardi/flutter_speed_dial
 
@@ -13,7 +13,7 @@ dev_dependencies:
     sdk: flutter
 
 environment:
-  sdk: ">=1.20.1 <3.0.0"
+  sdk: ">=2.2.2 <3.0.0"
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec


### PR DESCRIPTION
Hello!!
When looking into the code I realized that it was creating a lot of unnecessary AnimationControllers, one for each children of the main FAB. 
Also, you were starting those controllers by using Timers with 40millis of duration. 
All that was causing some janky animations on lower end devices (and even on some high end).

I removed those controllers and now the library just need one! Much more lightweight and performatic!
This "master" controller is being 'tweened' by Interval curves calculated by the amount of children on the fab's children list.
