### PR TITLE
Adding size for buttons

### DIFF
--- a/lib/src/animated_child.dart
+++ b/lib/src/animated_child.dart
@@ -39,7 +39,7 @@ class AnimatedChild extends AnimatedWidget {
 
   Widget buildLabel() {
     final Animation<double> animation = listenable;
-    if (!visible && animation.value != buttonSize {
+    if (!visible && animation.value != buttonSize) {
       return Container();
     }
     var child = labelWidget;

--- a/lib/src/animated_child.dart
+++ b/lib/src/animated_child.dart
@@ -39,7 +39,7 @@ class AnimatedChild extends AnimatedWidget {
 
   Widget buildLabel() {
     final Animation<double> animation = listenable;
-    if (!visible && animation.value != 62.00) {
+    if (!visible && animation.value != buttonSize {
       return Container();
     }
     var child = labelWidget;

--- a/lib/src/animated_child.dart
+++ b/lib/src/animated_child.dart
@@ -5,6 +5,7 @@ class AnimatedChild extends AnimatedWidget {
   final Color backgroundColor;
   final Color foregroundColor;
   final double elevation;
+  final double buttonSize;
   final Widget child;
   final String label;
   final TextStyle labelStyle;
@@ -23,6 +24,7 @@ class AnimatedChild extends AnimatedWidget {
     this.backgroundColor,
     this.foregroundColor,
     this.elevation = 6.0,
+    this.buttonSize = 62,
     this.child,
     this.label,
     this.labelStyle,
@@ -94,11 +96,11 @@ class AnimatedChild extends AnimatedWidget {
         children: <Widget>[
           buildLabel(),
           Container(
-            width: 62.0,
+            width: buttonSize,
             height: animation.value,
-            padding: EdgeInsets.only(bottom: 62.0 - animation.value),
+            padding: EdgeInsets.only(bottom: buttonSize - animation.value),
             child: Container(
-              height: 62.0,
+              height: buttonSize,
               width: animation.value,
               padding: EdgeInsets.only(top: 8.0, bottom: 8.0),
               child: FloatingActionButton(

--- a/lib/src/speed_dial.dart
+++ b/lib/src/speed_dial.dart
@@ -152,6 +152,7 @@ class _SpeedDialState extends State<SpeedDial> with SingleTickerProviderStateMix
             backgroundColor: child.backgroundColor,
             foregroundColor: child.foregroundColor,
             elevation: child.elevation,
+            buttonSize: child.buttonSize,
             child: child.child,
             label: child.label,
             labelWidget: child.labelWidget,

--- a/lib/src/speed_dial_child.dart
+++ b/lib/src/speed_dial_child.dart
@@ -17,6 +17,7 @@ class SpeedDialChild {
   final Color backgroundColor;
   final Color foregroundColor;
   final double elevation;
+  final double buttonSize;
   final VoidCallback onTap;
   final ShapeBorder shape;
 
@@ -28,6 +29,7 @@ class SpeedDialChild {
     this.backgroundColor,
     this.foregroundColor,
     this.elevation,
+    this.buttonSize,
     this.onTap,
     this.shape,
     this.labelWidget


### PR DESCRIPTION
New material design guidelines require different sizes of icons for FAB, see screenshot below from Google Calendar.
![Screenshot_20191017-105539_Calendar](https://user-images.githubusercontent.com/6979719/67056987-54e12200-f157-11e9-93b3-aec89172c88a.jpg)
