### PR TITLE
Added option to customize orientation of the child buttons.

### DIFF
--- a/lib/flutter_speed_dial.dart
+++ b/lib/flutter_speed_dial.dart
@@ -2,3 +2,4 @@ library flutter_speed_dial;
 
 export 'src/speed_dial.dart';
 export 'src/speed_dial_child.dart';
+export 'src/speed_dial_orientation.dart';

--- a/lib/src/speed_dial.dart
+++ b/lib/src/speed_dial.dart
@@ -4,6 +4,7 @@ import 'animated_child.dart';
 import 'animated_floating_button.dart';
 import 'background_overlay.dart';
 import 'speed_dial_child.dart';
+import 'speed_dial_orientation.dart';
 
 /// Builds the Speed Dial
 class SpeedDial extends StatefulWidget {
@@ -56,29 +57,32 @@ class SpeedDial extends StatefulWidget {
   /// The speed of the animation
   final int animationSpeed;
 
-  SpeedDial({
-    this.children = const [],
-    this.visible = true,
-    this.backgroundColor,
-    this.foregroundColor,
-    this.elevation = 6.0,
-    this.overlayOpacity = 0.8,
-    this.overlayColor = Colors.white,
-    this.tooltip,
-    this.heroTag,
-    this.animatedIcon,
-    this.animatedIconTheme,
-    this.child,
-    this.marginBottom = 16,
-    this.marginRight = 16,
-    this.onOpen,
-    this.onClose,
-    this.closeManually = false,
-    this.shape = const CircleBorder(),
-    this.curve = Curves.linear,
-    this.onPress,
-    this.animationSpeed = 150
-  });
+  /// The orientation of the children. Default is [SpeedDialOrientation.Up]
+  final SpeedDialOrientation orientation;
+
+  SpeedDial(
+      {this.children = const [],
+      this.visible = true,
+      this.backgroundColor,
+      this.foregroundColor,
+      this.elevation = 6.0,
+      this.overlayOpacity = 0.8,
+      this.overlayColor = Colors.white,
+      this.tooltip,
+      this.heroTag,
+      this.animatedIcon,
+      this.animatedIconTheme,
+      this.child,
+      this.marginBottom = 16,
+      this.marginRight = 16,
+      this.onOpen,
+      this.onClose,
+      this.orientation = SpeedDialOrientation.Up,
+      this.closeManually = false,
+      this.shape = const CircleBorder(),
+      this.curve = Curves.linear,
+      this.onPress,
+      this.animationSpeed = 150});
 
   @override
   _SpeedDialState createState() => _SpeedDialState();
@@ -217,23 +221,44 @@ class _SpeedDialState extends State<SpeedDial> with SingleTickerProviderStateMix
       curve: widget.curve,
     );
 
-    return Positioned(
-      bottom: widget.marginBottom - 16,
-      right: widget.marginRight - 16,
-      child: Container(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.end,
-          crossAxisAlignment: CrossAxisAlignment.end,
-          children: List.from(fabChildren)
-            ..add(
-              Container(
-                margin: EdgeInsets.only(top: 8.0, right: 2.0),
-                child: animatedFloatingButton,
-              ),
+    switch (widget.orientation) {
+      case SpeedDialOrientation.Up:
+        return Positioned(
+          bottom: widget.marginBottom - 16,
+          right: widget.marginRight - 16,
+          child: Container(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.end,
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: List.from(fabChildren)
+                ..add(Container(
+                  margin: EdgeInsets.only(top: 8.0, right: 2.0),
+                  child: animatedFloatingButton,
+                )),
             ),
-        ),
-      ),
-    );
+          ),
+        );
+        break;
+      case SpeedDialOrientation.Down:
+        return Positioned(
+          top: MediaQuery.of(context).size.height - 56 - 8 - (widget.marginBottom - 16),
+          right: widget.marginRight - 16,
+          child: Container(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.end,
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: List.from(fabChildren)
+                ..insert(
+                    0,
+                    Container(
+                      margin: EdgeInsets.only(top: 8.0, right: 2.0),
+                      child: animatedFloatingButton,
+                    )),
+            ),
+          ),
+        );
+        break;
+    }
   }
 
   @override

--- a/lib/src/speed_dial.dart
+++ b/lib/src/speed_dial.dart
@@ -247,7 +247,7 @@ class _SpeedDialState extends State<SpeedDial> with SingleTickerProviderStateMix
             child: Column(
               mainAxisAlignment: MainAxisAlignment.end,
               crossAxisAlignment: CrossAxisAlignment.end,
-              children: List.from(fabChildren)
+              children: List.from(fabChildren.reversed)
                 ..insert(
                     0,
                     Container(

--- a/lib/src/speed_dial.dart
+++ b/lib/src/speed_dial.dart
@@ -60,29 +60,30 @@ class SpeedDial extends StatefulWidget {
   /// The orientation of the children. Default is [SpeedDialOrientation.Up]
   final SpeedDialOrientation orientation;
 
-  SpeedDial(
-      {this.children = const [],
-      this.visible = true,
-      this.backgroundColor,
-      this.foregroundColor,
-      this.elevation = 6.0,
-      this.overlayOpacity = 0.8,
-      this.overlayColor = Colors.white,
-      this.tooltip,
-      this.heroTag,
-      this.animatedIcon,
-      this.animatedIconTheme,
-      this.child,
-      this.marginBottom = 16,
-      this.marginRight = 16,
-      this.onOpen,
-      this.onClose,
-      this.orientation = SpeedDialOrientation.Up,
-      this.closeManually = false,
-      this.shape = const CircleBorder(),
-      this.curve = Curves.linear,
-      this.onPress,
-      this.animationSpeed = 150});
+  SpeedDial({
+    this.children = const [],
+    this.visible = true,
+    this.backgroundColor,
+    this.foregroundColor,
+    this.elevation = 6.0,
+    this.overlayOpacity = 0.8,
+    this.overlayColor = Colors.white,
+    this.tooltip,
+    this.heroTag,
+    this.animatedIcon,
+    this.animatedIconTheme,
+    this.child,
+    this.marginBottom = 16,
+    this.marginRight = 16,
+    this.onOpen,
+    this.onClose,
+    this.orientation = SpeedDialOrientation.Up,
+    this.closeManually = false,
+    this.shape = const CircleBorder(),
+    this.curve = Curves.linear,
+    this.onPress,
+    this.animationSpeed = 150
+  });
 
   @override
   _SpeedDialState createState() => _SpeedDialState();
@@ -222,7 +223,27 @@ class _SpeedDialState extends State<SpeedDial> with SingleTickerProviderStateMix
     );
 
     switch (widget.orientation) {
+      case SpeedDialOrientation.Down:
+        return Positioned(
+          top: MediaQuery.of(context).size.height - 56 - (widget.marginBottom - 16),
+          right: widget.marginRight - 16,
+          child: Container(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.end,
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: List.from(fabChildren.reversed)
+                ..insert(
+                    0,
+                    Container(
+                      margin: EdgeInsets.only(bottom: 8.0, right: 2.0),
+                      child: animatedFloatingButton,
+                    )),
+            ),
+          ),
+        );
+        break;
       case SpeedDialOrientation.Up:
+      default:
         return Positioned(
           bottom: widget.marginBottom - 16,
           right: widget.marginRight - 16,
@@ -238,26 +259,7 @@ class _SpeedDialState extends State<SpeedDial> with SingleTickerProviderStateMix
             ),
           ),
         );
-        break;
-      case SpeedDialOrientation.Down:
-        return Positioned(
-          top: MediaQuery.of(context).size.height - 56 - 8 - (widget.marginBottom - 16),
-          right: widget.marginRight - 16,
-          child: Container(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.end,
-              crossAxisAlignment: CrossAxisAlignment.end,
-              children: List.from(fabChildren.reversed)
-                ..insert(
-                    0,
-                    Container(
-                      margin: EdgeInsets.only(top: 8.0, right: 2.0),
-                      child: animatedFloatingButton,
-                    )),
-            ),
-          ),
-        );
-        break;
+        break;  
     }
   }
 

--- a/lib/src/speed_dial_orientation.dart
+++ b/lib/src/speed_dial_orientation.dart
@@ -1,0 +1,4 @@
+enum SpeedDialOrientation {
+  Up,
+  Down
+}


### PR DESCRIPTION
This PR adds an option to customize the orientation of the child buttons per my feature request in issue #53. They can open either above or below the FAB.

Obviously you could easily add other orientations, but that involves making lots more decisions about label direction and orientation.