### PR TITLE
restrict stack size to button size when closed

### DIFF
--- a/lib/src/speed_dial.dart
+++ b/lib/src/speed_dial.dart
@@ -243,11 +243,21 @@ class _SpeedDialState extends State<SpeedDial> with SingleTickerProviderStateMix
       _renderButton(),
     ];
 
-    return Stack(
+    var stack = Stack(
       alignment: Alignment.bottomRight,
       fit: StackFit.expand,
       overflow: Overflow.visible,
       children: children,
     );
+
+    if (_open) {
+      return stack;
+    } else {
+      return Container(
+        width: 56,
+        height: 56,
+        child: stack,
+      );
+    }
   }
 }


### PR DESCRIPTION
This change avoids the unwanted animation as described and shown in #12

The problem is that the stack spans across the whole screen to display the overlay. Unfortunately, the entry animation then rotates and zooms the whole stack, not only the button. This makes it look like the button originates from the middle of the screen.