### PR TITLE
Migration to Null Safety

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -12,7 +12,7 @@ class MyApp extends StatefulWidget {
 }
 
 class MyAppState extends State<MyApp> with TickerProviderStateMixin {
-  ScrollController scrollController;
+  ScrollController? scrollController;
   bool dialVisible = true;
 
   @override
@@ -21,7 +21,7 @@ class MyAppState extends State<MyApp> with TickerProviderStateMixin {
 
     scrollController = ScrollController()
       ..addListener(() {
-        setDialVisible(scrollController.position.userScrollDirection ==
+        setDialVisible(scrollController!.position.userScrollDirection ==
             ScrollDirection.forward);
       });
   }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: flutter_speed_dial example.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/lib/src/animated_child.dart
+++ b/lib/src/animated_child.dart
@@ -1,35 +1,35 @@
 import 'package:flutter/material.dart';
 
 class AnimatedChild extends AnimatedWidget {
-  final int index;
-  final Color backgroundColor;
-  final Color foregroundColor;
-  final double elevation;
+  final int? index;
+  final Color? backgroundColor;
+  final Color? foregroundColor;
+  final double? elevation;
   final double buttonSize;
-  final Widget child;
-  final Key key;
+  final Widget? child;
+  final Key? key;
 
-  final String label;
-  final TextStyle labelStyle;
-  final Color labelBackgroundColor;
-  final Widget labelWidget;
+  final String? label;
+  final TextStyle? labelStyle;
+  final Color? labelBackgroundColor;
+  final Widget? labelWidget;
 
   final bool visible;
-  final bool dark;
-  final VoidCallback onTap;
-  final VoidCallback onLongPress;
-  final VoidCallback toggleChildren;
-  final ShapeBorder shape;
-  final String heroTag;
+  final bool? dark;
+  final VoidCallback? onTap;
+  final VoidCallback? onLongPress;
+  final VoidCallback? toggleChildren;
+  final ShapeBorder? shape;
+  final String? heroTag;
 
-  final double childMarginBottom;
-  final double childMarginTop;
+  final double? childMarginBottom;
+  final double? childMarginTop;
   final double _paddingPercent = 0.125;
   final bool useInkWell;
 
   AnimatedChild({
     this.key,
-    Animation<double> animation,
+    required Animation<double> animation,
     this.index,
     this.backgroundColor,
     this.foregroundColor,
@@ -53,7 +53,7 @@ class AnimatedChild extends AnimatedWidget {
   }) : super(listenable: animation);
 
   Widget buildLabel() {
-    final Animation<double> animation = listenable;
+    final Animation<double> animation = listenable as Animation<double>;
 
     if (!((label != null || labelWidget != null) &&
         visible &&
@@ -75,38 +75,38 @@ class AnimatedChild extends AnimatedWidget {
       child: Container(
         padding: EdgeInsets.symmetric(vertical: 5.0, horizontal: 8.0),
         margin: EdgeInsetsDirectional.fromSTEB(
-            0, childMarginTop, 18.0, childMarginBottom),
+            0, childMarginTop!, 18.0, childMarginBottom!),
         decoration: BoxDecoration(
           color: labelBackgroundColor ??
-              (dark ? Colors.grey[800] : Colors.grey[50]),
+              (dark! ? Colors.grey[800] : Colors.grey[50]),
           borderRadius: BorderRadius.all(Radius.circular(6.0)),
           boxShadow: [
             BoxShadow(
-              color: dark
-                  ? Colors.grey[900].withOpacity(0.7)
+              color: dark!
+                  ? Colors.grey[900]!.withOpacity(0.7)
                   : Colors.grey.withOpacity(0.7),
               offset: Offset(0.8, 0.8),
               blurRadius: 2.4,
             )
           ],
         ),
-        child: Text(label, style: labelStyle),
+        child: Text(label!, style: labelStyle),
       ),
     );
   }
 
   void _performAction() {
-    if (onTap != null) onTap();
-    toggleChildren();
+    if (onTap != null) onTap!();
+    toggleChildren!();
   }
 
   void _performLongAction() {
-    if (onLongPress != null) onLongPress();
-    toggleChildren();
+    if (onLongPress != null) onLongPress!();
+    toggleChildren!();
   }
 
   Widget build(BuildContext context) {
-    final Animation<double> animation = listenable;
+    final Animation<double> animation = listenable as Animation<double>;
 
     final Widget buttonChild = animation.value > buttonSize*0.9 && child !=null
         ? Container(
@@ -124,8 +124,8 @@ class AnimatedChild extends AnimatedWidget {
       heroTag: heroTag,
       onPressed: _performAction,
       backgroundColor:
-          backgroundColor ?? (dark ? Colors.grey[800] : Colors.grey[50]),
-      foregroundColor: foregroundColor ?? (dark ? Colors.white : Colors.black),
+          backgroundColor ?? (dark! ? Colors.grey[800] : Colors.grey[50]),
+      foregroundColor: foregroundColor ?? (dark! ? Colors.white : Colors.black),
       elevation: elevation ?? 6.0,
       child: buttonChild,
       shape: shape,
@@ -162,14 +162,14 @@ class AnimatedChild extends AnimatedWidget {
   }
 
   Widget useGestureOrInkWell(
-      {Function onTap, Function onLongPress, Widget child}) {
+      {Function? onTap, Function? onLongPress, Widget? child}) {
     return useInkWell
         ? InkWell(
-            onLongPress: onLongPress,
+            onLongPress: onLongPress as void Function()?,
             child: child,
           )
         : GestureDetector(
-            onLongPress: onLongPress,
+            onLongPress: onLongPress as void Function()?,
             child: child,
           );
   }

--- a/lib/src/animated_floating_button.dart
+++ b/lib/src/animated_floating_button.dart
@@ -2,23 +2,23 @@ import 'package:flutter/material.dart';
 
 class AnimatedFloatingButton extends StatelessWidget {
   final bool visible;
-  final VoidCallback callback;
-  final VoidCallback onLongPress;
-  final Widget label;
-  final Widget child;
-  final Color backgroundColor;
-  final Color foregroundColor;
-  final String tooltip;
-  final String heroTag;
+  final VoidCallback? callback;
+  final VoidCallback? onLongPress;
+  final Widget? label;
+  final Widget? child;
+  final Color? backgroundColor;
+  final Color? foregroundColor;
+  final String? tooltip;
+  final String? heroTag;
   final double elevation;
   final double size;
   final ShapeBorder shape;
   final Curve curve;
-  final Widget dialRoot;
-  final bool useInkWell;
+  final Widget? dialRoot;
+  final bool? useInkWell;
 
   AnimatedFloatingButton({
-    Key key,
+    Key? key,
     this.visible = true,
     this.callback,
     this.label,
@@ -61,7 +61,7 @@ class AnimatedFloatingButton extends StatelessWidget {
                       key: key,
                       icon: visible ? child : null,
                       shape: shape == CircleBorder() ? StadiumBorder() : shape,
-                      label: visible ? label : null,
+                      label: visible ? label! : SizedBox(),
                       backgroundColor: backgroundColor,
                       foregroundColor: foregroundColor,
                       onPressed: callback,
@@ -88,16 +88,16 @@ class AnimatedFloatingButton extends StatelessWidget {
   }
 
   Widget useGestureOrInkWell(
-      {Function onTap, Function onLongPress, Widget child}) {
-    return useInkWell
+      {Function? onTap, Function? onLongPress, Widget? child}) {
+    return useInkWell!
         ? InkWell(
-            onLongPress: onLongPress,
-            onTap: onTap,
+            onLongPress: onLongPress as void Function()?,
+            onTap: onTap as void Function()?,
             child: child,
           )
         : GestureDetector(
-            onLongPress: onLongPress,
-            onTap: onTap,
+            onLongPress: onLongPress as void Function()?,
+            onTap: onTap as void Function()?,
             child: child,
           );
   }

--- a/lib/src/background_overlay.dart
+++ b/lib/src/background_overlay.dart
@@ -3,20 +3,20 @@ library flutter_speed_dial;
 import 'package:flutter/material.dart';
 
 class BackgroundOverlay extends AnimatedWidget {
-  final Color color;
+  final Color? color;
   final double opacity;
 
   BackgroundOverlay({
-    Key key,
-    Animation<double> animation,
+    Key? key,
+    required Animation<double> animation,
     this.color = Colors.white,
     this.opacity = 0.8,
   }) : super(key: key, listenable: animation);
 
   Widget build(BuildContext context) {
-    final Animation<double> animation = listenable;
+    final Animation<double> animation = listenable as Animation<double>;
     return Container(
-      color: color.withOpacity(animation.value * opacity),
+      color: color!.withOpacity(animation.value * opacity),
     );
   }
 }

--- a/lib/src/speed_dial.dart
+++ b/lib/src/speed_dial.dart
@@ -20,60 +20,60 @@ class SpeedDial extends StatefulWidget {
   /// The curve used to animate the button on scrolling.
   final Curve curve;
 
-  final String tooltip;
-  final String heroTag;
-  final Color backgroundColor;
-  final Color foregroundColor;
+  final String? tooltip;
+  final String? heroTag;
+  final Color? backgroundColor;
+  final Color? foregroundColor;
   final double elevation;
   final double buttonSize;
   final ShapeBorder shape;
-  final Gradient gradient;
+  final Gradient? gradient;
   final BoxShape gradientBoxShape;
 
   final double marginEnd;
   final double marginBottom;
 
   /// The color of the background overlay.
-  final Color overlayColor;
+  final Color? overlayColor;
 
   /// The opacity of the background overlay when the dial is open.
   final double overlayOpacity;
 
   /// The animated icon to show as the main button child. If this is provided the [child] is ignored.
-  final AnimatedIconData animatedIcon;
+  final AnimatedIconData? animatedIcon;
 
   /// The theme for the animated icon.
-  final IconThemeData animatedIconTheme;
+  final IconThemeData? animatedIconTheme;
 
   /// The icon of the main button, ignored if [animatedIcon] is non [null].
-  final IconData icon;
+  final IconData? icon;
 
   /// The active icon of the main button, Defaults to icon if not specified, ignored if [animatedIcon] is non [null].
-  final IconData activeIcon;
+  final IconData? activeIcon;
 
   /// If true then rotation animation will be used when animating b/w activeIcon and icon.
   final bool useRotationAnimation;
 
   /// The theme for the icon generally includes color and size.
-  final IconThemeData iconTheme;
+  final IconThemeData? iconTheme;
 
   /// The label of the main button.
-  final Widget label;
+  final Widget? label;
 
   /// The active label of the main button, Defaults to label if not specified.
-  final Widget activeLabel;
+  final Widget? activeLabel;
 
   /// Transition Builder between label and activeLabel, defaults to FadeTransition.
-  final Widget Function(Widget, Animation<double>) labelTransitionBuilder;
+  final Widget Function(Widget, Animation<double>)? labelTransitionBuilder;
 
   /// Executed when the dial is opened.
-  final VoidCallback onOpen;
+  final VoidCallback? onOpen;
 
   /// Executed when the dial is closed.
-  final VoidCallback onClose;
+  final VoidCallback? onClose;
 
   /// Executed when the dial is pressed. If given, the dial only opens on long press!
-  final VoidCallback onPress;
+  final VoidCallback? onPress;
 
   /// If true user is forced to close dial manually by tapping main button. WARNING: If true, overlay is not rendered.
   final bool closeManually;
@@ -82,7 +82,7 @@ class SpeedDial extends StatefulWidget {
   final bool renderOverlay;
 
   /// Open or close the dial via a notification
-  final ValueNotifier<bool> openCloseDial;
+  final ValueNotifier<bool>? openCloseDial;
 
   /// The speed of the animation in milliseconds
   final int animationSpeed;
@@ -101,21 +101,21 @@ class SpeedDial extends StatefulWidget {
   /// ignore backgroundColor, foregroundColor or any other property
   /// that was specific to FAB before like onPress, you will have to provide
   /// it again to your dialRoot button.
-  final Widget dialRoot;
+  final Widget? dialRoot;
 
   /// If Provided then it will use Inkwell
   /// for onLongPress instead of GestureDetector on Top of Root Widget
   final bool useInkWell;
 
   /// This is the child of the FAB, if specified it will ignore icon, activeIcon.
-  final Widget child;
+  final Widget? child;
 
   /// This is the active child of the FAB, if specified it will animate b/w this
   /// and the child.
-  final Widget activeChild;
+  final Widget? activeChild;
 
   SpeedDial({
-    Key key,
+    Key? key,
     this.children = const [],
     this.visible = true,
     this.backgroundColor,
@@ -160,11 +160,11 @@ class SpeedDial extends StatefulWidget {
   @override
   _SpeedDialState createState() => _SpeedDialState();
 
-  bool _dark;
+  bool? _dark;
 }
 
 class _SpeedDialState extends State<SpeedDial> with TickerProviderStateMixin {
-  AnimationController _controller;
+  late AnimationController _controller;
 
   bool _open = false;
 
@@ -228,11 +228,11 @@ class _SpeedDialState extends State<SpeedDial> with TickerProviderStateMixin {
       setState(() {
         _open = newValue;
       });
-      if (widget.openCloseDial != null) widget.openCloseDial.value = newValue;
-      if (newValue && widget.onOpen != null) widget.onOpen();
+      if (widget.openCloseDial != null) widget.openCloseDial!.value = newValue;
+      if (newValue && widget.onOpen != null) widget.onOpen!();
       _performAnimation();
-      if (!newValue && widget.onClose != null) widget.onClose();
-    } else if (widget.onOpen != null) widget.onOpen();
+      if (!newValue && widget.onClose != null) widget.onClose!();
+    } else if (widget.onOpen != null) widget.onOpen!();
   }
 
   List<Widget> _getChildrenList() {
@@ -295,7 +295,7 @@ class _SpeedDialState extends State<SpeedDial> with TickerProviderStateMixin {
         child: BackgroundOverlay(
           animation: _controller,
           color: widget.overlayColor ??
-              (widget._dark ? Colors.grey[900] : Colors.white),
+              (widget._dark! ? Colors.grey[900] : Colors.white),
           opacity: widget.overlayOpacity,
         ),
       ),
@@ -309,7 +309,7 @@ class _SpeedDialState extends State<SpeedDial> with TickerProviderStateMixin {
             height: widget.buttonSize,
             child: Center(
               child: AnimatedIcon(
-                icon: widget.animatedIcon,
+                icon: widget.animatedIcon!,
                 progress: _controller,
                 color: widget.animatedIconTheme?.color,
                 size: widget.animatedIconTheme?.size,
@@ -322,7 +322,7 @@ class _SpeedDialState extends State<SpeedDial> with TickerProviderStateMixin {
           )
         : AnimatedBuilder(
             animation: _controller,
-            builder: (BuildContext context, Widget _widget) => Transform(
+            builder: (BuildContext context, Widget? _widget) => Transform(
               transform: Matrix4.rotationZ(_controller.value * 0.5 * pi),
               alignment: FractionalOffset.center,
               child: AnimatedSwitcher(
@@ -373,7 +373,7 @@ class _SpeedDialState extends State<SpeedDial> with TickerProviderStateMixin {
     var label = AnimatedSwitcher(
       duration: Duration(milliseconds: widget.animationSpeed),
       transitionBuilder: widget.labelTransitionBuilder != null
-          ? widget.labelTransitionBuilder
+          ? widget.labelTransitionBuilder!
           : (child, animation) => FadeTransition(
                 opacity: animation,
                 child: child,
@@ -392,9 +392,9 @@ class _SpeedDialState extends State<SpeedDial> with TickerProviderStateMixin {
       tooltip: widget.tooltip,
       dialRoot: widget.dialRoot,
       backgroundColor: widget.backgroundColor ??
-          (widget._dark ? Colors.grey[800] : Colors.grey[50]),
+          (widget._dark! ? Colors.grey[800] : Colors.grey[50]),
       foregroundColor: widget.foregroundColor ??
-          (widget._dark ? Colors.white : Colors.black),
+          (widget._dark! ? Colors.white : Colors.black),
       elevation: widget.elevation,
       onLongPress: _toggleChildren,
       callback:

--- a/lib/src/speed_dial_child.dart
+++ b/lib/src/speed_dial_child.dart
@@ -3,28 +3,28 @@ import 'package:flutter/material.dart';
 /// Provides data for a speed dial child
 class SpeedDialChild {
   /// The key of the speed dial child.
-  final Key key;
+  final Key? key;
 
   /// The label to render to the left of the button
-  final String label;
+  final String? label;
 
   /// The style of the label
-  final TextStyle labelStyle;
+  final TextStyle? labelStyle;
 
   /// The background color of the label
-  final Color labelBackgroundColor;
+  final Color? labelBackgroundColor;
 
   /// If this is provided it will replace the default widget, therefore [label],
   /// [labelStyle] and [labelBackgroundColor] should be null
-  final Widget labelWidget;
+  final Widget? labelWidget;
 
-  final Widget child;
-  final Color backgroundColor;
-  final Color foregroundColor;
-  final double elevation;
-  final VoidCallback onTap;
-  final VoidCallback onLongPress;
-  final ShapeBorder shape;
+  final Widget? child;
+  final Color? backgroundColor;
+  final Color? foregroundColor;
+  final double? elevation;
+  final VoidCallback? onTap;
+  final VoidCallback? onLongPress;
+  final ShapeBorder? shape;
 
   SpeedDialChild({
     this.key,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,6 @@ dev_dependencies:
     sdk: flutter
 
 environment:
-  sdk: ">=2.2.2 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 flutter:


### PR DESCRIPTION
This PR is simply running the `dart migrate` tool and only making it so if the label is not passed to a `FloatingButton`, a `SizedBox()` is passed for the null case