### PR TITLE
Fixed #113

### DIFF
--- a/lib/src/speed_dial.dart
+++ b/lib/src/speed_dial.dart
@@ -382,7 +382,7 @@ class _SpeedDialState extends State<SpeedDial> with TickerProviderStateMixin {
           : widget.activeLabel,
     );
 
-    var fabChildren = _open ? _getChildrenList() : [];
+    var fabChildren = _getChildrenList();
 
     var animatedFloatingButton = AnimatedFloatingButton(
       key: widget.key,


### PR DESCRIPTION
The problem is that when the state is close, the children are removing from widget tree and we're losing the closing animation. So the easiest fix was to always add children to the widget tree. I tested it a bit and I didn't notice any issues.