### PR TITLE
Fix widget state interaction after dispose

### DIFF
--- a/lib/src/speed_dial.dart
+++ b/lib/src/speed_dial.dart
@@ -187,13 +187,7 @@ class _SpeedDialState extends State<SpeedDial>
   @override
   void initState() {
     super.initState();
-    widget.openCloseDial?.addListener(() {
-      final show = widget.openCloseDial?.value;
-      if (!mounted) return;
-      if (_open != show) {
-        _toggleChildren();
-      }
-    });
+    widget.openCloseDial?.addListener(_onOpenCloseDial);
     Future.delayed(Duration.zero, () async {
       if (mounted && widget.isOpenOnStart) _toggleChildren();
     });
@@ -202,7 +196,7 @@ class _SpeedDialState extends State<SpeedDial>
   @override
   void dispose() {
     _controller.dispose();
-    widget.openCloseDial?.removeListener(() {});
+    widget.openCloseDial?.removeListener(_onOpenCloseDial);
     super.dispose();
   }
 
@@ -212,19 +206,22 @@ class _SpeedDialState extends State<SpeedDial>
       _controller.duration = Duration(milliseconds: widget.animationSpeed);
     }
 
-    widget.openCloseDial?.removeListener(() {});
-    widget.openCloseDial?.addListener(() {
-      final show = widget.openCloseDial?.value;
-      if (!mounted) return;
-      if (_open != show) {
-        _toggleChildren();
-      }
-    });
-
+    widget.openCloseDial?.removeListener(_onOpenCloseDial);
+    widget.openCloseDial?.addListener(_onOpenCloseDial);
     super.didUpdateWidget(oldWidget);
   }
 
+  void _onOpenCloseDial() {
+    final show = widget.openCloseDial?.value;
+    if (!mounted) return;
+    if (_open != show) {
+      _toggleChildren();
+    }
+  }
+
   void _toggleChildren() {
+    if (!mounted) return;
+
     if (widget.children.length > 0) {
       var newValue = !_open;
       toggleOverlay();


### PR DESCRIPTION
Hello!
After updating to v4.2 from v3.x I have encountered some errors logs in the Sentry dashboard of a production app coming from the package. Here are some examples:

```
_CastError: Null check operator used on a null value
  libapp              0x6d72af1b14 _SpeedDialState.toggleOverlay.<T> (package:flutter_speed_dial/src/speed_dial.dart:341)
  libapp              0x6d72b7653c _OverlayEntryWidgetState.build (package:flutter/src/widgets/overlay.dart:208)
  libapp              0x6d72db90a4 StatefulElement.build (package:flutter/src/widgets/framework.dart:4691)
  libapp              0x6d72a16c4c ComponentElement.performRebuild (package:flutter/src/widgets/framework.dart:4574)
```

```
_CastError: Null check operator used on a null value
  libapp              0x7714decfd4 BackgroundOverlay.build (package:flutter_speed_dial/src/background_overlay.dart:45)
  libapp              0x7714ba9334 _AnimatedState.build (package:flutter/src/widgets/transitions.dart:174)
  libapp              0x7714de90a4 StatefulElement.build (package:flutter/src/widgets/framework.dart:4691)
  libapp              0x7714a46c4c ComponentElement.performRebuild (package:flutter/src/widgets/framework.dart:4574)
```

```
_CastError: Null check operator used on a null value
  libapp              0x717fb28ad8 AnimationController.stop (package:flutter/src/animation/animation_controller.dart:777)
  libapp              0x717fb297b8 AnimationController._animateToInternal (package:flutter/src/animation/animation_controller.dart:597)
  libapp              0x717fb29520 AnimationController.reverse (package:flutter/src/animation/animation_controller.dart:495)
  libapp              0x717fe2df4c _SpeedDialState.toggleOverlay (package:flutter_speed_dial/src/speed_dial.dart:301)
  libapp              0x717fe2de9c _SpeedDialState._toggleChildren (package:flutter_speed_dial/src/speed_dial.dart:230)
  libapp              0x717fb4676c GestureRecognizer.invokeCallback (package:flutter/src/gestures/recognizer.dart:182)
  libapp              0x71801e8d00 TapGestureRecognizer.handleTapUp (package:flutter/src/gestures/tap.dart:607)
```

All three seem to indicate that the widget is doing setState or similar after it has been disposed, so I've included an is mounted check.

I've also updated the openCloseDial listener disposal by pointing to the same function. I that the following doesn't work 
` widget.openCloseDial?.removeListener(() {});`
It would simply remove a listener that has never been saved in the first place.