### PR TITLE
Fix for #213, adding horizontal padding when the size is larger then 56

### DIFF
--- a/lib/src/speed_dial.dart
+++ b/lib/src/speed_dial.dart
@@ -363,6 +363,12 @@ class _SpeedDialState extends State<SpeedDial>
                     child: Material(
                       type: MaterialType.transparency,
                       child: Container(
+                        padding: EdgeInsets.symmetric(
+                          horizontal:
+                              widget.direction.isUp || widget.direction.isDown
+                                  ? max(widget.buttonSize - 56, 0) / 2
+                                  : 0,
+                        ),
                         margin: widget.spacing != null
                             ? EdgeInsets.fromLTRB(
                                 widget.direction.isRight ? widget.spacing! : 0,


### PR DESCRIPTION
This aligns child buttons with the center of the FAB.