### PR TITLE
Change the dispose order and dispose the overlayEntry first

### DIFF
--- a/lib/src/speed_dial.dart
+++ b/lib/src/speed_dial.dart
@@ -248,13 +248,13 @@ class _SpeedDialState extends State<SpeedDial>
 
   @override
   void dispose() {
-    if (widget.renderOverlay && backgroundOverlay != null) {
-      if (backgroundOverlay!.mounted) backgroundOverlay!.remove();
-      backgroundOverlay!.dispose();
-    }
     if (overlayEntry != null) {
       if (overlayEntry!.mounted) overlayEntry!.remove();
       overlayEntry!.dispose();
+    }
+    if (widget.renderOverlay && backgroundOverlay != null) {
+      if (backgroundOverlay!.mounted) backgroundOverlay!.remove();
+      backgroundOverlay!.dispose();
     }
     _controller.dispose();
     widget.openCloseDial?.removeListener(_onOpenCloseDial);


### PR DESCRIPTION
I had the same problems as described in ticket #297. After I changed the order of the dispose function by disposing the entry overlay first, the error does not appear anymore.

Due to the error described in the ticket, the background was not cleared properly for an app running in profile/release mode. So the background was still drawed also when the user has pop/push another page.

Also working with ValueNotifier led to the same error.  

I think maybe it has something to do with the order how the overlays are inserted. So we can see here:
```dart
if (widget.renderOverlay) Overlay.of(context)!.insert(backgroundOverlay!);
Overlay.of(context)!.insert(overlayEntry!);
```

So the insert method (if below and above attributes are null) insert the overlay always on top. In this case first the backgroundOverlay and then the entryOverlay.

I think the dispose order should be then from the top stack so at first the entry and then the background. And this was not the case. 
